### PR TITLE
Add some server metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION  := 0.0.1
+VERSION  := 0.1.0
 TARGET   := bind_exporter
 
 include Makefile.COMMON

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION  := 0.1.0
+VERSION  := 0.1.1
 TARGET   := bind_exporter
 
 include Makefile.COMMON

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # Bind Exporter
 
-Export Bind(named/dns) v9+ service metrics to Prometheus. 
+Export BIND(named/dns) v9+ service metrics to Prometheus.
 
-To run it:
+## Getting started
 
 ```bash
 make
 ./bind_exporter [flags]
 ```
 
-### Flags
+## Troubeshooting
 
-```bash
-./bind_exporter --help
+Make sure BIND was built with libxml2 support. You can check with the following
+command: `named -V | grep libxml2`.
+
+Configure BIND to open a statistics channel. It's recommended to run the
+bind_exporter next to BIND, so it's only necessary to open a port locally.
+
+```
+statistics-channels {
+  inet 127.0.0.1 port 8080 allow { 127.0.0.1; };
+};
 ```

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -310,7 +310,7 @@ func histogram(stats []Stat) (map[float64]uint64, uint64, error) {
 
 func main() {
 	var (
-		listenAddress = flag.String("web.listen-address", ":9109", "Address to listen on for web interface and telemetry.")
+		listenAddress = flag.String("web.listen-address", ":9119", "Address to listen on for web interface and telemetry.")
 		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 		bindURI       = flag.String("bind.statsuri", "http://localhost:8053/", "HTTP XML API address of an Bind server.")
 		bindTimeout   = flag.Duration("bind.timeout", 10*time.Second, "Timeout for trying to get stats from Bind.")

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -35,7 +35,7 @@ var (
 	)
 	incomingRequests = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "incoming_requests_total"),
-		"Number of incomming DNS queries.",
+		"Number of incomming DNS requests.",
 		[]string{"name"}, nil,
 	)
 	resolverCache = prometheus.NewDesc(
@@ -46,7 +46,7 @@ var (
 	resolverQueries = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, resolver, "queries_total"),
 		"Number of outgoing DNS queries.",
-		[]string{"view", "name"}, nil,
+		[]string{"view", "type"}, nil,
 	)
 	resolverQueryDuration = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, resolver, "query_duration_seconds"),

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -31,12 +31,17 @@ var (
 	incomingQueries = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "incoming_queries_total"),
 		"Number of incomming DNS queries.",
-		[]string{"name"}, nil,
+		[]string{"type"}, nil,
 	)
 	incomingRequests = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "incoming_requests_total"),
 		"Number of incomming DNS queries.",
 		[]string{"name"}, nil,
+	)
+	resolverCache = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, resolver, "cache_rrsets"),
+		"Number of RRSets in Cache database.",
+		[]string{"view", "type"}, nil,
 	)
 	resolverQueries = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, resolver, "queries_total"),
@@ -206,6 +211,12 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	for _, v := range stats.Views {
+		for _, s := range v.Cache {
+			ch <- prometheus.MustNewConstMetric(
+				resolverCache, prometheus.GaugeValue, float64(s.Counter), v.Name, s.Name,
+			)
+		}
+
 		for _, s := range v.Rdtype {
 			ch <- prometheus.MustNewConstMetric(
 				resolverQueries, prometheus.CounterValue, float64(s.Counter), v.Name, s.Name,

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -111,18 +111,26 @@ var (
 		"ValOk":         resolverDNSSECSucess,
 		"ValNegOk":      resolverDNSSECSucess,
 	}
+	serverQueryErrors = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "query_errors_total"),
+		"Number of query failures.",
+		[]string{"error"}, nil,
+	)
 	serverReponses = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "responses_total"),
 		"Number of responses sent.",
 		[]string{"result"}, nil,
 	)
 	serverLabelStats = map[string]*prometheus.Desc{
-		"QrySuccess":  serverReponses,
-		"QryReferral": serverReponses,
-		"QryNxrrset":  serverReponses,
-		"QrySERVFAIL": serverReponses,
-		"QryFORMERR":  serverReponses,
-		"QryNXDOMAIN": serverReponses,
+		"QryDuplicate": serverQueryErrors,
+		"QryDropped":   serverQueryErrors,
+		"QryFailure":   serverQueryErrors,
+		"QrySuccess":   serverReponses,
+		"QryReferral":  serverReponses,
+		"QryNxrrset":   serverReponses,
+		"QrySERVFAIL":  serverReponses,
+		"QryFORMERR":   serverReponses,
+		"QryNXDOMAIN":  serverReponses,
 	}
 	tasksRunning = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "tasks_running"),

--- a/struct.go
+++ b/struct.go
@@ -30,18 +30,34 @@ type View struct {
 
 //TODO expand
 type Socket struct {
-	Id           string `xml:"id"`
+	ID           string `xml:"id"`
 	Name         string `xml:"name"`
 	LocalAddress string `xml:"local-address"`
+	References   uint   `xml:"references"`
 }
 
 type Socketmgr struct {
-	References int      `xml:"references"`
-	Sockets    []Socket `xml:"sockets>socket"`
+	Sockets []Socket `xml:"sockets>socket"`
+}
+
+type Task struct {
+	ID         string `xml:"id"`
+	Name       string `xml:"name"`
+	Quantum    uint   `xml:"quantum"`
+	References uint   `xml:"references"`
+	State      string `xml:"state"`
+}
+
+type ThreadModel struct {
+	Type           string `xml:"type"`
+	WorkerThreads  uint   `xml:"worker-threads"`
+	DefaultQuantum uint   `xml:"default-quantum"`
+	TasksRunning   uint   `xml:"tasks-running"`
 }
 
 type Taskmgr struct {
-	//TODO
+	Tasks       []Task      `xml:"tasks>task"`
+	ThreadModel ThreadModel `xml:"thread-model"`
 }
 
 type QueriesIn struct {

--- a/struct.go
+++ b/struct.go
@@ -73,7 +73,7 @@ type Server struct {
 	Requests  Requests  `xml:"requests"`   //Most important stats
 	QueriesIn QueriesIn `xml:"queries-in"` //Most important stats
 
-	NsStats     []Stat `xml:"nstat"`
+	NsStats     []Stat `xml:"nsstat"`
 	SocketStats []Stat `xml:"socketstat"`
 	ZoneStats   []Stat `xml:"zonestats"`
 }

--- a/struct.go
+++ b/struct.go
@@ -38,7 +38,8 @@ type Socket struct {
 }
 
 type Socketmgr struct {
-	Sockets []Socket `xml:"sockets>socket"`
+	References uint     `xml:"references"`
+	Sockets    []Socket `xml:"sockets>socket"`
 }
 
 type Task struct {

--- a/struct.go
+++ b/struct.go
@@ -18,14 +18,15 @@ type Zone struct {
 
 type Stat struct {
 	Name    string `xml:"name"`
-	Counter int    `xml:"counter"`
+	Counter uint   `xml:"counter"`
 }
 
 type View struct {
 	Name    string `xml:"name"`
-	Zones   []Zone `xml:"zones>zone"`
-	Resstat []Stat `xml:"resstat"`
+	Cache   []Stat `xml:"cache>rrset"`
 	Rdtype  []Stat `xml:"rdtype"`
+	Resstat []Stat `xml:"resstat"`
+	Zones   []Zone `xml:"zones>zone"`
 }
 
 //TODO expand


### PR DESCRIPTION
* bind_tasks_running (current) and bind_worker_threads (limit) for process insight
* add resolver cache DB content metric
* add server responses metric (alert on many serverfail responses)
* add servery query errors metric (alert if the server drops many incoming queries)
* rename name labels to type as that's what the dns RFCs use for records
* change default port (9109 was already taken, marked it in https://github.com/prometheus/prometheus/wiki/Default-port-allocations)
* bump version to 0.1.1

@mattkanwisher Let me know if you have any questions or change requests. Sorry for bumping the version already, I needed to release it quickly for a project.