### PR TITLE
Support zone stats, enable some initial zone transfer metrics

### DIFF
--- a/bind/bind.go
+++ b/bind/bind.go
@@ -90,6 +90,7 @@ type Server struct {
 	IncomingQueries  []Counter
 	IncomingRequests []Counter
 	NameServerStats  []Counter
+	ZoneStatistics   []Counter
 }
 
 // View represents statistics for a single BIND view.

--- a/bind/v2/v2.go
+++ b/bind/v2/v2.go
@@ -86,6 +86,9 @@ func (c *Client) Stats(...bind.StatisticGroup) (bind.Statistics, error) {
 	for _, t := range stats.Server.NSStats {
 		s.Server.NameServerStats = append(s.Server.NameServerStats, bind.Counter(t))
 	}
+	for _, t := range stats.Server.ZoneStats {
+		s.Server.ZoneStatistics = append(s.Server.ZoneStatistics, bind.Counter(t))
+	}
 	for _, view := range stats.Views {
 		v := bind.View{
 			Name:  view.Name,

--- a/bind/v3/v3.go
+++ b/bind/v3/v3.go
@@ -20,6 +20,7 @@ const (
 	qtype    = "qtype"
 	resqtype = "resqtype"
 	resstats = "resstats"
+	zonestat = "zonestat"
 )
 
 type Statistics struct {
@@ -87,6 +88,8 @@ func (c *Client) Stats(groups ...bind.StatisticGroup) (bind.Statistics, error) {
 				s.Server.IncomingQueries = c.Counters
 			case nsstat:
 				s.Server.NameServerStats = c.Counters
+			case zonestat:
+				s.Server.ZoneStatistics = c.Counters
 			}
 		}
 

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/digitalocean/bind_exporter/bind"
 	"github.com/digitalocean/bind_exporter/bind/auto"
-	v2 "github.com/digitalocean/bind_exporter/bind/v2"
-	v3 "github.com/digitalocean/bind_exporter/bind/v3"
+	"github.com/digitalocean/bind_exporter/bind/v2"
+	"github.com/digitalocean/bind_exporter/bind/v3"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/digitalocean/bind_exporter/bind"
 	"github.com/digitalocean/bind_exporter/bind/auto"
-	"github.com/digitalocean/bind_exporter/bind/v2"
-	"github.com/digitalocean/bind_exporter/bind/v3"
+	v2 "github.com/digitalocean/bind_exporter/bind/v2"
+	v3 "github.com/digitalocean/bind_exporter/bind/v3"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
@@ -158,6 +158,21 @@ var (
 			"Number of queries causing recursion.",
 			nil, nil,
 		),
+		"XfrRej": prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "zone_transfer_rejected_total"),
+			"Number of rejected zone transfers.",
+			nil, nil,
+		),
+		"XfrSuccess": prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "zone_transfer_success_total"),
+			"Number of successful zone transfers.",
+			nil, nil,
+		),
+		"XfrFail": prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "zone_transfer_failure_total"),
+			"Number of failed zone transfers.",
+			nil, nil,
+		),
 	}
 	tasksRunning = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "tasks_running"),
@@ -222,6 +237,13 @@ func (c *serverCollector) Collect(ch chan<- prometheus.Metric) {
 				desc, prometheus.CounterValue, float64(s.Counter), r,
 			)
 		}
+		if desc, ok := serverMetricStats[s.Name]; ok {
+			ch <- prometheus.MustNewConstMetric(
+				desc, prometheus.CounterValue, float64(s.Counter),
+			)
+		}
+	}
+	for _, s := range c.stats.Server.ZoneStatistics {
 		if desc, ok := serverMetricStats[s.Name]; ok {
 			ch <- prometheus.MustNewConstMetric(
 				desc, prometheus.CounterValue, float64(s.Counter),

--- a/bind_exporter_test.go
+++ b/bind_exporter_test.go
@@ -22,6 +22,9 @@ var (
 		`bind_query_errors_total{error="Dropped"} 237`,
 		`bind_query_errors_total{error="Failure"} 2950`,
 		`bind_query_recursions_total 60946`,
+		`bind_zone_transfer_rejected_total 3`,
+		`bind_zone_transfer_success_total 25`,
+		`bind_zone_transfer_failure_total 1`,
 	}
 	serverStatsV3 = combine(serverStatsV2, []string{
 		`bind_config_time_seconds 1.473202712e+09`,

--- a/fixtures/v2.xml
+++ b/fixtures/v2.xml
@@ -1716,7 +1716,7 @@
         </nsstat>
         <nsstat>
           <name>XfrRej</name>
-          <counter>0</counter>
+          <counter>3</counter>
         </nsstat>
         <nsstat>
           <name>UpdateRej</name>
@@ -1876,11 +1876,11 @@
         </zonestat>
         <zonestat>
           <name>XfrSuccess</name>
-          <counter>0</counter>
+          <counter>25</counter>
         </zonestat>
         <zonestat>
           <name>XfrFail</name>
-          <counter>0</counter>
+          <counter>1</counter>
         </zonestat>
         <resstat>
           <name>Mismatch</name>

--- a/fixtures/v3/server
+++ b/fixtures/v3/server
@@ -37,7 +37,7 @@
       <counter name="ReqTCP">0</counter>
       <counter name="AuthQryRej">0</counter>
       <counter name="RecQryRej">0</counter>
-      <counter name="XfrRej">0</counter>
+      <counter name="XfrRej">3</counter>
       <counter name="UpdateRej">0</counter>
       <counter name="Response">156</counter>
       <counter name="TruncatedResp">0</counter>
@@ -92,8 +92,8 @@
       <counter name="AXFRReqv6">0</counter>
       <counter name="IXFRReqv4">0</counter>
       <counter name="IXFRReqv6">0</counter>
-      <counter name="XfrSuccess">0</counter>
-      <counter name="XfrFail">0</counter>
+      <counter name="XfrSuccess">25</counter>
+      <counter name="XfrFail">1</counter>
     </counters>
     <counters type="resstat"/>
   </server>


### PR DESCRIPTION
Unsure if this project has been deprecated, but we wanted to expose some of the zone transfer metrics to alert on transfer failures/rejections.

Creating a PR to pull these in as `server` stats in case it might be wanted by others.