### PR TITLE
better flag defaults

### DIFF
--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -465,7 +465,7 @@ func main() {
 		listenAddress = flag.String("web.listen-address", ":9119", "Address to listen on for web interface and telemetry.")
 		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 
-		groups = statisticGroups{bind.ServerStats, bind.ViewStats}
+		groups = statisticGroups{bind.ServerStats, bind.ViewStats, bind.TaskStats}
 	)
 	flag.Var(&groups, "bind.stats-groups", "Comma-separated list of statistics to collect. Available: [server, view, tasks]")
 	flag.Parse()

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -459,7 +459,7 @@ func main() {
 	var (
 		bindURI       = flag.String("bind.stats-url", "http://localhost:8053/", "HTTP XML API address of an Bind server.")
 		bindTimeout   = flag.Duration("bind.timeout", 10*time.Second, "Timeout for trying to get stats from Bind.")
-		bindPidFile   = flag.String("bind.pid-file", "", "Path to Bind's pid file to export process information.")
+		bindPidFile   = flag.String("bind.pid-file", "/run/named/named.pid", "Path to Bind's pid file to export process information.")
 		bindVersion   = flag.String("bind.stats-version", "auto", "BIND statistics version. Can be detected automatically. Available: [xml.v2, xml.v3, auto]")
 		showVersion   = flag.Bool("version", false, "Print version information.")
 		listenAddress = flag.String("web.listen-address", ":9119", "Address to listen on for web interface and telemetry.")


### PR DESCRIPTION
It's unclear to me why some flags are not enabled by default. The `tasks` part is useful in itself and shouldn't increase cardinality much. Similarly, the `pid` file support is really useful for the exporter to extract more info about running processes. The [official dashboard](https://grafana.com/dashboards/1666) expects both of those to be available for some graphs, which will look inexplicably blank otherwise.

So it seems to me fair to have proper defaults that are synchronized with the dashboard here. The PID file one is a bit of guesswork, but `/run` has become fairly standard now so it should work out of the box in most cases. In the worst case, users have to configure it which is the current situation anyways.